### PR TITLE
feature: update eslint dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,8 +12,8 @@
         "packages/*"
       ],
       "devDependencies": {
-        "@lvce-editor/eslint-config": "^17.0.3",
-        "eslint": "^10.7.0",
+        "@lvce-editor/eslint-config": "^17.5.0",
+        "eslint": "^10.8.0",
         "prettier": "^3.7.4",
         "typescript": "^6.0.0"
       }
@@ -1363,19 +1363,6 @@
         }
       }
     },
-    "node_modules/@e18e/eslint-plugin/node_modules/semver": {
-      "version": "7.8.5",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
-      "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
-      "dev": true,
-      "license": "ISC",
-      "bin": {
-        "semver": "bin/semver.js"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
     "node_modules/@esbuild/aix-ppc64": {
       "version": "0.27.2",
       "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.27.2.tgz",
@@ -1915,9 +1902,9 @@
       }
     },
     "node_modules/@eslint/config-helpers": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/@eslint/config-helpers/-/config-helpers-0.6.0.tgz",
-      "integrity": "sha512-ii6Bw9jJ2zi2cWA2Z+9/QZ/+3DX6kwaV5Q986D/CdP3Lap3w/pgQZ373FV7byY/i7L4IRH/G43I5dz1ClsCbpA==",
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/@eslint/config-helpers/-/config-helpers-0.7.0.tgz",
+      "integrity": "sha512-DObd/KKUsU+FaFv4PLxSRenpXfQWmPXXP3pPZ6/K1PCrMu2vQpMDMuQe/BqYeoLcz8ro0bVDF1RxOJgfVEdhUw==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -2941,11 +2928,14 @@
       "link": true
     },
     "node_modules/@lvce-editor/eslint-config": {
-      "version": "17.0.3",
-      "resolved": "https://registry.npmjs.org/@lvce-editor/eslint-config/-/eslint-config-17.0.3.tgz",
-      "integrity": "sha512-ChzOGQfCDANWLZlaR05tO6880FDTz9RZ+ATbijYSEByVDzdMSCgoDBPOzOXKDyCpeIR6KZ2I+O80mvNKTYlEgw==",
+      "version": "17.5.0",
+      "resolved": "https://registry.npmjs.org/@lvce-editor/eslint-config/-/eslint-config-17.5.0.tgz",
+      "integrity": "sha512-wjDaVd24PNVZdjbV8EcQYrbEWsKAJ9mak03EUIMTT6+tHVwlg9G1P2eDvqpxyMSmY3ywBKhAPigEjY2pwnCGUQ==",
       "dev": true,
       "license": "MIT",
+      "workspaces": [
+        "packages/*"
+      ],
       "dependencies": {
         "@cspell/eslint-plugin": "10.0.1",
         "@e18e/eslint-plugin": "^0.5.1",
@@ -2953,14 +2943,15 @@
         "@eslint/js": "10.0.1",
         "@eslint/json": "2.0.1",
         "@eslint/markdown": "8.0.3",
-        "@lvce-editor/eslint-plugin-devcontainer": "17.0.3",
-        "@lvce-editor/eslint-plugin-e2e": "17.0.3",
-        "@lvce-editor/eslint-plugin-github-actions": "17.0.3",
-        "@lvce-editor/eslint-plugin-nvmrc": "17.0.3",
-        "@lvce-editor/eslint-plugin-regex": "17.0.3",
-        "@lvce-editor/eslint-plugin-rpc": "17.0.3",
-        "@lvce-editor/eslint-plugin-tsconfig": "17.0.3",
-        "@lvce-editor/eslint-plugin-virtual-dom": "17.0.3",
+        "@lvce-editor/eslint-plugin-devcontainer": "17.5.0",
+        "@lvce-editor/eslint-plugin-e2e": "17.5.0",
+        "@lvce-editor/eslint-plugin-extension-json": "17.5.0",
+        "@lvce-editor/eslint-plugin-github-actions": "17.5.0",
+        "@lvce-editor/eslint-plugin-nvmrc": "17.5.0",
+        "@lvce-editor/eslint-plugin-regex": "17.5.0",
+        "@lvce-editor/eslint-plugin-rpc": "17.5.0",
+        "@lvce-editor/eslint-plugin-tsconfig": "17.5.0",
+        "@lvce-editor/eslint-plugin-virtual-dom": "17.5.0",
         "eslint-plugin-jest": "29.15.4",
         "eslint-plugin-n": "18.2.1",
         "eslint-plugin-package-json": "1.5.0",
@@ -2975,9 +2966,9 @@
       }
     },
     "node_modules/@lvce-editor/eslint-plugin-devcontainer": {
-      "version": "17.0.3",
-      "resolved": "https://registry.npmjs.org/@lvce-editor/eslint-plugin-devcontainer/-/eslint-plugin-devcontainer-17.0.3.tgz",
-      "integrity": "sha512-9lKoUZZitH134WxgfjGsYS8I2p5/e2bdwMCAtSuc31+a9Q/atpRSqStUSlsyumRxt781lgRdUvn9/jhGzTEoUQ==",
+      "version": "17.5.0",
+      "resolved": "https://registry.npmjs.org/@lvce-editor/eslint-plugin-devcontainer/-/eslint-plugin-devcontainer-17.5.0.tgz",
+      "integrity": "sha512-wNemW3CGngT/bRzB2ldVWW5++V/Xq549Hkbf7ZCc00XGxJhupZKTAYL3qCQvpdT5OJTUFc58Z9ddg42OLVENiQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2985,16 +2976,26 @@
       }
     },
     "node_modules/@lvce-editor/eslint-plugin-e2e": {
-      "version": "17.0.3",
-      "resolved": "https://registry.npmjs.org/@lvce-editor/eslint-plugin-e2e/-/eslint-plugin-e2e-17.0.3.tgz",
-      "integrity": "sha512-vE+DWFSlacnLOtHEhp5YS3q8Z0s0OQOBKYDvXG8g8fHyMGEQ2HFkE+WcIBe3LejQ39F2edh+y+vEs8xPgL8u0g==",
+      "version": "17.5.0",
+      "resolved": "https://registry.npmjs.org/@lvce-editor/eslint-plugin-e2e/-/eslint-plugin-e2e-17.5.0.tgz",
+      "integrity": "sha512-xGWeOY+aitgaKgxCVeRSJfEWMLf39u5wnq0uA3ZnZKFWXEHpZO3CaJi+9rw7KgFK7TcqgpxsaAHTENYEoabJHQ==",
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@lvce-editor/eslint-plugin-extension-json": {
+      "version": "17.5.0",
+      "resolved": "https://registry.npmjs.org/@lvce-editor/eslint-plugin-extension-json/-/eslint-plugin-extension-json-17.5.0.tgz",
+      "integrity": "sha512-F7qOAYW1LhFntc2f5Yn1QQqArqgVLi1tW6vRNzgWIptlrZTib0cGFG4jKOL7ZgB5uDl0mZWlZ9q1Q1T055eWhg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@eslint/json": "2.0.1"
+      }
+    },
     "node_modules/@lvce-editor/eslint-plugin-github-actions": {
-      "version": "17.0.3",
-      "resolved": "https://registry.npmjs.org/@lvce-editor/eslint-plugin-github-actions/-/eslint-plugin-github-actions-17.0.3.tgz",
-      "integrity": "sha512-+LMl161bH/f6iS4H+Uc/9lkZnF7jZOxChV2ghn0u9v3326r0rIfbE2eUiaWWZIxh2ox1qWXPWyGhyqxkdkUBjw==",
+      "version": "17.5.0",
+      "resolved": "https://registry.npmjs.org/@lvce-editor/eslint-plugin-github-actions/-/eslint-plugin-github-actions-17.5.0.tgz",
+      "integrity": "sha512-RhphHPbVQHqRu2yAZ/XnUdpP67BbPrIIrAvdkqSnitCVu65DDTTN1YVZMNdNv8cYue8V3V8eUMIf8WaNFBdJEQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3003,46 +3004,33 @@
       }
     },
     "node_modules/@lvce-editor/eslint-plugin-nvmrc": {
-      "version": "17.0.3",
-      "resolved": "https://registry.npmjs.org/@lvce-editor/eslint-plugin-nvmrc/-/eslint-plugin-nvmrc-17.0.3.tgz",
-      "integrity": "sha512-KmcXC9mDB5a6aAYon+OP60ybRmfdlShu8EefEbkm+pL3+ZBvOBpaj0haHnCTD2sXBBiZCPqBsyIK6kuZSsVg0w==",
+      "version": "17.5.0",
+      "resolved": "https://registry.npmjs.org/@lvce-editor/eslint-plugin-nvmrc/-/eslint-plugin-nvmrc-17.5.0.tgz",
+      "integrity": "sha512-mYcLlKt8Y2wKlM13xFXKaYDvKDOj/O5nnfj51oW7UTItROxtlD848eaXcxpLrH5iLTW5wC3G3Oz9ftwoGmqq7A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "semver": "^7.8.5"
       }
     },
-    "node_modules/@lvce-editor/eslint-plugin-nvmrc/node_modules/semver": {
-      "version": "7.8.5",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
-      "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
-      "dev": true,
-      "license": "ISC",
-      "bin": {
-        "semver": "bin/semver.js"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
     "node_modules/@lvce-editor/eslint-plugin-regex": {
-      "version": "17.0.3",
-      "resolved": "https://registry.npmjs.org/@lvce-editor/eslint-plugin-regex/-/eslint-plugin-regex-17.0.3.tgz",
-      "integrity": "sha512-QcDlgWoQdTkdt3CIINvQ+ZzKUJeYvPXq1s7AInPpqVHvkpmJAOkOst3lFDRNnLDcbW7HR3iynhzC54TqUNOqnw==",
+      "version": "17.5.0",
+      "resolved": "https://registry.npmjs.org/@lvce-editor/eslint-plugin-regex/-/eslint-plugin-regex-17.5.0.tgz",
+      "integrity": "sha512-PER04Hz35vvDFWXPK9wkSyAXB/H5aGGPE6i8nesbmGUP43fqT+7f9Kf5wzRUbUOdZ8HuFcnVQZALMbaEe1NcSg==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/@lvce-editor/eslint-plugin-rpc": {
-      "version": "17.0.3",
-      "resolved": "https://registry.npmjs.org/@lvce-editor/eslint-plugin-rpc/-/eslint-plugin-rpc-17.0.3.tgz",
-      "integrity": "sha512-LATOZfFUtuweBsCHJr8EpZv9CnKyFTKQ/JCPK8z3dHGXv/313pmGamN+N7qMioMXnzAL6M5OFRFpA2yBEU6euw==",
+      "version": "17.5.0",
+      "resolved": "https://registry.npmjs.org/@lvce-editor/eslint-plugin-rpc/-/eslint-plugin-rpc-17.5.0.tgz",
+      "integrity": "sha512-7dfk74/7pFDK2fWnDK1M8OP46ehlMiK2TlOZYvsg3kU0J4dC0m7emnwvWKCgzyd/rNVPsTyqcz8PSM3U+4Lf4Q==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/@lvce-editor/eslint-plugin-tsconfig": {
-      "version": "17.0.3",
-      "resolved": "https://registry.npmjs.org/@lvce-editor/eslint-plugin-tsconfig/-/eslint-plugin-tsconfig-17.0.3.tgz",
-      "integrity": "sha512-eXADQLKjL0eGvYItn0yKfZIGjnide4Su9emR7tsKTNsSHowEPX5IMfk+z90106xsR9G33kTutre2o94AOSihkQ==",
+      "version": "17.5.0",
+      "resolved": "https://registry.npmjs.org/@lvce-editor/eslint-plugin-tsconfig/-/eslint-plugin-tsconfig-17.5.0.tgz",
+      "integrity": "sha512-505lmJeM12Bq5eTZ5FMjB7qmbSu0Xi8bjVCbBSjyMNAVhCAiEUfuWXq0TeiJFeT40GzF88On0GPYHxS+dviWmQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3050,9 +3038,9 @@
       }
     },
     "node_modules/@lvce-editor/eslint-plugin-virtual-dom": {
-      "version": "17.0.3",
-      "resolved": "https://registry.npmjs.org/@lvce-editor/eslint-plugin-virtual-dom/-/eslint-plugin-virtual-dom-17.0.3.tgz",
-      "integrity": "sha512-HbcAuxZ/8ZltmOanAqqpqsmL5YZh6kOQZXcyEtH0Xl+xkRJlC3hS2KAEtWDANsHYZJsbM6S7fR4pdORcgiHcKg==",
+      "version": "17.5.0",
+      "resolved": "https://registry.npmjs.org/@lvce-editor/eslint-plugin-virtual-dom/-/eslint-plugin-virtual-dom-17.5.0.tgz",
+      "integrity": "sha512-sGiPawCOnR4E/8Bb+NTLlPpmvYS/t2vYrPwoG9/KVUq6gRnj3M34pQw2vsxP9A+PYig5LeL9TX5Wjj//DYVpXA==",
       "dev": true,
       "license": "MIT"
     },
@@ -5999,19 +5987,6 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
-    "node_modules/@typescript-eslint/typescript-estree/node_modules/semver": {
-      "version": "7.8.5",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
-      "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
-      "dev": true,
-      "license": "ISC",
-      "bin": {
-        "semver": "bin/semver.js"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
     "node_modules/@typescript-eslint/typescript-estree/node_modules/tinyglobby": {
       "version": "0.2.17",
       "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.17.tgz",
@@ -8137,9 +8112,9 @@
       }
     },
     "node_modules/eslint": {
-      "version": "10.7.0",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-10.7.0.tgz",
-      "integrity": "sha512-GVTD7s1vdIl6UYvAfriOPeY1Df8LIZjfofLvHwde+erDHGGuHyuM6xoxRxmHiebhYuD2p1vN4wWh0XzPARSGDQ==",
+      "version": "10.8.0",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-10.8.0.tgz",
+      "integrity": "sha512-nuKKvN+oIBO0koN7Tm7dlkmnkc21mtt0QJLwAKzjLq14y6lRTdVG36MZHJ8eQHwdJMwZbQNMlPOYedMq/oVJvQ==",
       "dev": true,
       "license": "MIT",
       "workspaces": [
@@ -8149,7 +8124,7 @@
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.2",
         "@eslint/config-array": "^0.23.5",
-        "@eslint/config-helpers": "^0.6.0",
+        "@eslint/config-helpers": "^0.7.0",
         "@eslint/core": "^1.2.1",
         "@eslint/plugin-kit": "^0.7.2",
         "@humanfs/node": "^0.16.6",
@@ -8173,7 +8148,7 @@
         "imurmurhash": "^0.1.4",
         "is-glob": "^4.0.0",
         "json-stable-stringify-without-jsonify": "^1.0.1",
-        "minimatch": "^10.2.4",
+        "minimatch": "^10.2.5",
         "natural-compare": "^1.4.0",
         "optionator": "^0.9.3"
       },
@@ -8209,19 +8184,6 @@
       },
       "peerDependencies": {
         "eslint": ">=6.0.0"
-      }
-    },
-    "node_modules/eslint-compat-utils/node_modules/semver": {
-      "version": "7.8.5",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
-      "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
-      "dev": true,
-      "license": "ISC",
-      "bin": {
-        "semver": "bin/semver.js"
-      },
-      "engines": {
-        "node": ">=10"
       }
     },
     "node_modules/eslint-fix-utils": {
@@ -8303,19 +8265,6 @@
         "eslint": ">=6.0.0"
       }
     },
-    "node_modules/eslint-plugin-es-x/node_modules/semver": {
-      "version": "7.8.5",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
-      "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
-      "dev": true,
-      "license": "ISC",
-      "bin": {
-        "semver": "bin/semver.js"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
     "node_modules/eslint-plugin-jest": {
       "version": "29.15.4",
       "resolved": "https://registry.npmjs.org/eslint-plugin-jest/-/eslint-plugin-jest-29.15.4.tgz",
@@ -8382,19 +8331,6 @@
         }
       }
     },
-    "node_modules/eslint-plugin-n/node_modules/semver": {
-      "version": "7.8.5",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
-      "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
-      "dev": true,
-      "license": "ISC",
-      "bin": {
-        "semver": "bin/semver.js"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
     "node_modules/eslint-plugin-package-json": {
       "version": "1.5.0",
       "resolved": "https://registry.npmjs.org/eslint-plugin-package-json/-/eslint-plugin-package-json-1.5.0.tgz",
@@ -8425,19 +8361,6 @@
         "@eslint/json": {
           "optional": true
         }
-      }
-    },
-    "node_modules/eslint-plugin-package-json/node_modules/semver": {
-      "version": "7.8.5",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
-      "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
-      "dev": true,
-      "license": "ISC",
-      "bin": {
-        "semver": "bin/semver.js"
-      },
-      "engines": {
-        "node": ">=10"
       }
     },
     "node_modules/eslint-plugin-perfectionist": {
@@ -8534,19 +8457,6 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
-    "node_modules/eslint-plugin-sonarjs/node_modules/semver": {
-      "version": "7.8.5",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
-      "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
-      "dev": true,
-      "license": "ISC",
-      "bin": {
-        "semver": "bin/semver.js"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
     "node_modules/eslint-plugin-unicorn": {
       "version": "71.1.0",
       "resolved": "https://registry.npmjs.org/eslint-plugin-unicorn/-/eslint-plugin-unicorn-71.1.0.tgz",
@@ -8593,19 +8503,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/eslint-plugin-unicorn/node_modules/semver": {
-      "version": "7.8.5",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
-      "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
-      "dev": true,
-      "license": "ISC",
-      "bin": {
-        "semver": "bin/semver.js"
-      },
-      "engines": {
-        "node": ">=10"
       }
     },
     "node_modules/eslint-plugin-yml": {
@@ -10074,19 +9971,6 @@
         "node": ">=10"
       }
     },
-    "node_modules/istanbul-lib-instrument/node_modules/semver": {
-      "version": "7.8.5",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
-      "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
-      "dev": true,
-      "license": "ISC",
-      "bin": {
-        "semver": "bin/semver.js"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
     "node_modules/istanbul-lib-report": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/istanbul-lib-report/-/istanbul-lib-report-3.0.1.tgz",
@@ -11216,19 +11100,6 @@
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
-    "node_modules/jest-snapshot/node_modules/semver": {
-      "version": "7.8.5",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
-      "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
-      "dev": true,
-      "license": "ISC",
-      "bin": {
-        "semver": "bin/semver.js"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
     "node_modules/jest-util": {
       "version": "30.0.5",
       "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-30.0.5.tgz",
@@ -11700,19 +11571,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/make-dir/node_modules/semver": {
-      "version": "7.8.5",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
-      "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
-      "dev": true,
-      "license": "ISC",
-      "bin": {
-        "semver": "bin/semver.js"
-      },
-      "engines": {
-        "node": ">=10"
       }
     },
     "node_modules/make-error": {
@@ -13168,19 +13026,6 @@
         "node": "^20.17.0 || >=22.9.0"
       }
     },
-    "node_modules/package-json-validator/node_modules/semver": {
-      "version": "7.8.5",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
-      "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
-      "dev": true,
-      "license": "ISC",
-      "bin": {
-        "semver": "bin/semver.js"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
     "node_modules/package-json-validator/node_modules/validate-npm-package-name": {
       "version": "7.0.2",
       "resolved": "https://registry.npmjs.org/validate-npm-package-name/-/validate-npm-package-name-7.0.2.tgz",
@@ -14051,29 +13896,13 @@
       }
     },
     "node_modules/semver": {
-      "version": "7.5.2",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.2.tgz",
-      "integrity": "sha512-SoftuTROv/cRjCze/scjGyiDtcUyxw1rgYQSZY7XTmtR5hX+dm76iDbTH8TkLPHCQmlbQVSSbNZCPM2hb0knnQ==",
+      "version": "7.8.5",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+      "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
       "dev": true,
       "license": "ISC",
-      "dependencies": {
-        "lru-cache": "^6.0.0"
-      },
       "bin": {
         "semver": "bin/semver.js"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/semver/node_modules/lru-cache": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
-      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "yallist": "^4.0.0"
       },
       "engines": {
         "node": ">=10"
@@ -14327,19 +14156,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/sort-package-json/node_modules/semver": {
-      "version": "7.8.5",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
-      "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
-      "dev": true,
-      "license": "ISC",
-      "bin": {
-        "semver": "bin/semver.js"
-      },
-      "engines": {
-        "node": ">=10"
       }
     },
     "node_modules/sort-package-json/node_modules/tinyglobby": {
@@ -15625,13 +15441,6 @@
         "node": ">=10"
       }
     },
-    "node_modules/yallist": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
-      "dev": true,
-      "license": "ISC"
-    },
     "node_modules/yaml": {
       "version": "2.9.0",
       "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.9.0.tgz",
@@ -15938,19 +15747,6 @@
         "@lvce-editor/verror": "^1.7.0",
         "jest": "^30.1.3",
         "ts-jest": "^29.4.4"
-      }
-    },
-    "packages/embeds-worker/node_modules/semver": {
-      "version": "7.8.5",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
-      "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
-      "dev": true,
-      "license": "ISC",
-      "bin": {
-        "semver": "bin/semver.js"
-      },
-      "engines": {
-        "node": ">=10"
       }
     },
     "packages/embeds-worker/node_modules/ts-jest": {

--- a/package.json
+++ b/package.json
@@ -24,8 +24,8 @@
     "printWidth": 150
   },
   "devDependencies": {
-    "@lvce-editor/eslint-config": "^17.0.3",
-    "eslint": "^10.7.0",
+    "@lvce-editor/eslint-config": "^17.5.0",
+    "eslint": "^10.8.0",
     "prettier": "^3.7.4",
     "typescript": "^6.0.0"
   }


### PR DESCRIPTION
## Summary
- update ESLint to 10.8.0
- update @lvce-editor/eslint-config to 17.5.0

## Validation
- npm run build
- npm run build:static
- npm test (3 passed)
- npm run type-check
- npm run lint
- packages/e2e: npm run e2e:headless
- packages/memory: npm run measure